### PR TITLE
Add vmbox entity id token

### DIFF
--- a/lib/hz2600/Kazoo/Api/Entity/VMBox.php
+++ b/lib/hz2600/Kazoo/Api/Entity/VMBox.php
@@ -2,7 +2,12 @@
 
 namespace Kazoo\Api\Entity;
 
+use \Kazoo\Common\ChainableInterface;
+
 class VMBox extends AbstractEntity
 {
-
+    public function __construct(ChainableInterface $chain, array $arguments = array()) {
+        parent::__construct($chain, $arguments);
+        $this->setTokenValue($this->getEntityIdName(), $this->getId());
+    }
 }


### PR DESCRIPTION
Since Messages are derived from a vmbox, the vmbox entitiy needs to have
its entity id properly set.