### PR TITLE
Fix voicemail media raw functionality

### DIFF
--- a/lib/hz2600/Kazoo/Api/Entity/Media.php
+++ b/lib/hz2600/Kazoo/Api/Entity/Media.php
@@ -14,7 +14,7 @@ class Media extends AbstractEntity
     {
         $this->setTokenValue($this->getEntityIdName(), $this->getId());
         $uri = $this->getURI('/raw');
-        $x   = $this->getSDK()->get($uri, array(), array('accept'=>'audio/*', 'content_type'=>'audio/*'));
+        $x   = $this->getSDK()->get($uri, array(), array('accept'=>'*/*', 'content_type'=>'audio/*'));
 
         header('Content-Type: '.$x->getHeader('Content-Type')[0]);
         header('content-length: '.$x->getHeader('content-length')[0]);

--- a/lib/hz2600/Kazoo/Api/Entity/Message.php
+++ b/lib/hz2600/Kazoo/Api/Entity/Message.php
@@ -1,7 +1,11 @@
 <?php
 namespace Kazoo\Api\Entity;
 
-class Message extends AbstractEntity
+class Message extends Media
 {
+
+	protected function getCollectionName(){
+        return "messages";
+    }
 
 }


### PR DESCRIPTION
Fixes the voicemail media functionality with the latest 4.0 changes.
Message is now a subclass of Media. Media also changes accept type to
*/*, otherwise request is rejected.