### PR TITLE
Add append URI for collection fetch requests

### DIFF
--- a/lib/hz2600/Kazoo/Api/Collection/AbstractCollection.php
+++ b/lib/hz2600/Kazoo/Api/Collection/AbstractCollection.php
@@ -82,8 +82,8 @@ abstract class AbstractCollection extends AbstractResource implements Iterator, 
      *
      *
      */
-    public function fetch(array $filter = array()) {
-        $response = $this->get($this->getFilter($filter));
+    public function fetch(array $filter = array(), $append_uri = '') {
+        $response = $this->get($this->getFilter($filter), $append_uri);
         $this->setCollection($response->getData());
         $this->rewind();
         return $this;


### PR DESCRIPTION
Some new v2 CDR API calls allow for getting interactionss. The SDK had
no way to add this to the URI used for a fetch.