### PR TITLE
Subclassed patch method not working

### DIFF
--- a/lib/hz2600/Kazoo/Api/Entity/AbstractEntity.php
+++ b/lib/hz2600/Kazoo/Api/Entity/AbstractEntity.php
@@ -182,7 +182,8 @@ abstract class AbstractEntity extends AbstractResource
 
         $this->setTokenValue($this->getEntityIdName(), $id);
 
-        $response = $this->patch($payload, $append_uri);
+        //$response = $this->patch($payload, $append_uri);
+        $response = parent::patch($payload, $append_uri);
 
         $entity = $response->getData();
         $this->setEntity($entity);


### PR DESCRIPTION
Remove the call to the AbstractEntity's subclassing of the patch method.
It is not working. Just call the parent which is what was called before.