### PR TITLE
Add magic method for isset

### DIFF
--- a/lib/hz2600/Kazoo/Api/Collection/ElementWrapper.php
+++ b/lib/hz2600/Kazoo/Api/Collection/ElementWrapper.php
@@ -72,6 +72,11 @@ class ElementWrapper
         throw new ReadOnly("Collection elements are read-only");
     }
 
+
+    public function __isset($name) {
+        return isset($this->getElement()->$name);
+    }
+
     /**
      *
      *


### PR DESCRIPTION
Not able to do an isset on a collection element. This fix solves that
problem. Previouysly all isset calls for attributes/memeber of a
collection element would return false