### PR TITLE
Fix missing media content type

### DIFF
--- a/lib/hz2600/Kazoo/Api/Entity/Media.php
+++ b/lib/hz2600/Kazoo/Api/Entity/Media.php
@@ -16,18 +16,16 @@ class Media extends AbstractEntity
         $uri = $this->getURI('/raw');
         $x   = $this->getSDK()->get($uri, array(), array('accept'=>'*/*', 'content_type'=>'audio/*'));
 
-        if ($justData) {
-            header('Content-Type: ' . $x->getHeader('Content-Type')[0]);
-            header('content-length: ' . $x->getHeader('content-length')[0]);
-        }
-
-        if (!$stream && !$justData) {
-            header('Content-Disposition: '.$x->getHeader('Content-Disposition')[0]);
-        }
-
-        if ($justData)
+		if ($justData)
         {
             return $x->getBody();
+        }
+		
+        header('Content-Type: ' . $x->getHeader('Content-Type')[0]);
+        header('content-length: ' . $x->getHeader('content-length')[0]);
+
+        if (!$stream) {
+            header('Content-Disposition: '.$x->getHeader('Content-Disposition')[0]);
         }
 
         echo $x->getBody();


### PR DESCRIPTION
the content type was not properly being output after adding the just
data option (needed to save media to a file). Wasn't an issue on desktop
browsers, but mobile browsers weren't working.